### PR TITLE
AWS provisioned servers that are disappearing from the Forge UI

### DIFF
--- a/1.0/resources/cookbook.md
+++ b/1.0/resources/cookbook.md
@@ -17,27 +17,3 @@ Forge uses `ufw` for the firewall, so once you've connected to the server you ne
 ```bash
 ufw allow 22
 ```
-
-## AWS provisioned servers are disappearing from the Forge UI
-
-To avoid this behaviour when provisioning servers in the Forge UI, select Create New for the VPC dropdown option.
-This will ensure that Forge will automatically create and configure the VPC and Security group needed for continues access from the Forge UI. 
-
-Alternatively, if you want to use any existing VPC, ensure that the VPC has IPv4 address range (IPv4 CIDR block) that covers your EC2 instances private IP's, as well as a Security Group associated with that VPC. 
-
-The Security Group needs to have these Inbound Rules:
-
-For TCP Connections
-```bash
-Type: All TCP
-Protocol: TCP
-Port range: 0 - 65535
-Source: 0.0.0.0/0
-```
-For UDP Connections
-```bash
-Type: All UDP
-Protocol: UDP
-Port range: 0 - 65535
-Source: 0.0.0.0/0
-```

--- a/1.0/resources/cookbook.md
+++ b/1.0/resources/cookbook.md
@@ -17,3 +17,27 @@ Forge uses `ufw` for the firewall, so once you've connected to the server you ne
 ```bash
 ufw allow 22
 ```
+
+## AWS provisioned servers are disappearing from the Forge UI
+
+To avoid this behaviour when provisioning servers in the Forge UI, select Create New for the VPC dropdown option.
+This will ensure that Forge will automatically create and configure the VPC and Security group needed for continues access from the Forge UI. 
+
+Alternatively, if you want to use any existing VPC, ensure that the VPC has IPv4 address range (IPv4 CIDR block) that covers your EC2 instances private IP's, as well as a Security Group associated with that VPC. 
+
+The Security Group needs to have these Inbound Rules:
+
+For TCP Connections
+```bash
+Type: All TCP
+Protocol: TCP
+Port range: 0 - 65535
+Source: 0.0.0.0/0
+```
+For UDP Connections
+```bash
+Type: All UDP
+Protocol: UDP
+Port range: 0 - 65535
+Source: 0.0.0.0/0
+```

--- a/1.0/servers/cookbook.md
+++ b/1.0/servers/cookbook.md
@@ -48,21 +48,23 @@ sudo apt-get install --only-upgrade nodejs
 
 ## AWS provisioned servers are disappearing from the Forge UI
 
-To avoid this behaviour when provisioning servers in the Forge UI, select Create New for the VPC dropdown option.
-This will ensure that Forge will automatically create and configure the VPC and Security group needed for continues access from the Forge UI. 
+To avoid this behaviour when provisioning servers in the Forge UI, select **Create New** in the VPC dropdown option. This will ensure that Forge will automatically create and configure the VPC and Security Group needed for continuous access from the Forge UI. 
 
-Alternatively, if you want to use any existing VPC, ensure that the VPC has IPv4 address range (IPv4 CIDR block) that covers your EC2 instances private IP's, as well as a Security Group associated with that VPC. 
+Alternatively, if you want to use any existing VPC, ensure that the VPC has IPv4 address range (IPv4 CIDR block) that covers your EC2 instance private IP addresses, as well as a Security Group associated with that VPC. 
 
 The Security Group needs to have these Inbound Rules:
 
-For TCP Connections
+For TCP Connections:
+
 ```
 Type: All TCP
 Protocol: TCP
 Port range: 0 - 65535
 Source: 0.0.0.0/0
 ```
-For UDP Connections
+
+For UDP Connections:
+
 ```
 Type: All UDP
 Protocol: UDP

--- a/1.0/servers/cookbook.md
+++ b/1.0/servers/cookbook.md
@@ -45,3 +45,27 @@ The latest version of Node.js is installed by Forge when it is provisioning a ne
 ```bash
 sudo apt-get install --only-upgrade nodejs
 ```
+
+## AWS provisioned servers are disappearing from the Forge UI
+
+To avoid this behaviour when provisioning servers in the Forge UI, select Create New for the VPC dropdown option.
+This will ensure that Forge will automatically create and configure the VPC and Security group needed for continues access from the Forge UI. 
+
+Alternatively, if you want to use any existing VPC, ensure that the VPC has IPv4 address range (IPv4 CIDR block) that covers your EC2 instances private IP's, as well as a Security Group associated with that VPC. 
+
+The Security Group needs to have these Inbound Rules:
+
+For TCP Connections
+```
+Type: All TCP
+Protocol: TCP
+Port range: 0 - 65535
+Source: 0.0.0.0/0
+```
+For UDP Connections
+```
+Type: All UDP
+Protocol: UDP
+Port range: 0 - 65535
+Source: 0.0.0.0/0
+```


### PR DESCRIPTION
This PR adds helpful info in the Cookbook section for AWS provisioned servers that are disappearing from the Forge UI. @jbrooksuk thanks for the suggestion which section is most appropriate for this kind of information. I've tried my best to describe the solution for the most popular use case, as well as provide a more "Technical" guideline for advanced users and use cases.

If you are interested in the full context for this PR, I'm providing the Forge tickets:
<details>
<summary>
First Ticket
</summary>

> Hi there,
> 
> I need assistance with AWS provisioning.
> 
> I have tried 3 times to provision a server in AWS - frankfurt region but with no luck.
> 
> The 3 tries were successful in terms of creating the stuff and to be visible in the AWS EC2 Dashboard however the server disappears from the Forge UI Dashboard, thus I cannot manage the created server(s) from Forge anymore.
> 
> The IAM user for the first two tries had the following permissions:
> AmazonEC2FullAccess
> and
> AmazonVPCFullAccess
> Then for the third time, I've added the permission:
> AdministratorAccess
> 
> I've managed to save this 2 links:
> https://forge.laravel.com/servers/ommited
> https://forge.laravel.com/servers/ommited
> At first, they were displaying Building and after a while only 404 not found
> 
> For debugging purposes I'm attaching some screenshots, I hope they help.
> 
> Since encountering the issues in the first two tries i have terminated the created servers from this tries as seen at the screenshot named ec2-dashboard, however, the last third try is online and the IP address is: **ommited**. The IP address did not change at all from creation till the missing part in the Forge UI (maybe this helps as info).
> Also I have not performed any manual steps while provisioning.
> Just added the AWS account in Forge then created a server with the following options:
> Credentials
> **ommited** Production
> 
> Name
> **ommited**-production
> Region
> Frankfurt
> 
> Server Size
> 2 vCPUs - 4GB RAM (t3.medium)
> 
> VPC
> vpc-**ommited**
> 
> Subnet
> subnet-**ommited**
> 
> PHP Version
> 7.3
> 
> Post-Provision Recipe
> None
> 
> Database
> Postgres (12)
> 
> Database Name
> **ommited**

</details>

<details>
<summary>
Second Ticket with an explanation of the solution
</summary>

> I've just tried with the VPC option Create New and it seems it's now moving further along in the provisioning process.
> 
> So the resolution is to not use the default VPC that comes with a new AWS account because the provisioning process will hang on the Building Stage somewhere and then Forge will delete it (archive it) automatically somehow probably because of network connectivity problems arising from the default VPC configurations.
> 
> Maybe this is worth documenting in the Forge docs? I can make a PR there but not sure what is the proper section for it: Maybe a new Troubleshoot section?

</details>
