### PR TITLE
Update server types breakdown table

### DIFF
--- a/1.0/servers/types.md
+++ b/1.0/servers/types.md
@@ -36,8 +36,8 @@ For reference, here is a breakdown of what is offered by each server type:
             <td scope="col">App Server</td>
             <td align="middle">✅</td>
             <td align="middle">✅</td>
-            <td align="middle"></td>
-            <td align="middle"></td>
+            <td align="middle">✅</td>
+            <td align="middle">✅</td>
             <td align="middle">✅</td>
             <td align="middle"></td>
         </tr>
@@ -45,8 +45,8 @@ For reference, here is a breakdown of what is offered by each server type:
             <td scope="col">Web Server</td>
             <td align="middle">✅</td>
             <td align="middle">✅</td>
-            <td align="middle">✅</td>
-            <td align="middle">✅</td>
+            <td align="middle"></td>
+            <td align="middle"></td>
             <td align="middle">✅</td>
             <td align="middle"></td>
         </tr>


### PR DESCRIPTION
The current breakdown table shows that a Web Server comes with a MySQL, Postgres or MariaDB database and Redis or Memcached. However, in the information a bit further down, it mentions that these aren't included with a Web Server and instead are included with the App Server.

Therefore, I believe the breakdown table should look like the following:

<img width="769" alt="Screenshot 2021-03-19 at 13 49 56" src="https://user-images.githubusercontent.com/22666637/111790818-844f0d80-88ba-11eb-9cc7-c6581c13b44f.png">
