### PR TITLE
feat: update whitelisting info

### DIFF
--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -37,7 +37,7 @@ If you are restricting SSH access to your server using IP allow lists, you shoul
 
 You can also access the IP addresses via the following URL: [https://forge.laravel.com/ips-v4.txt](https://forge.laravel.com/ips-v4.txt). This is particulary useful if you intend on automating your network or firewall infrastructure.
 
-Note that if your you are also restricting HTTPS traffic over port 443, you should also whitelist the domain `forge.laravel.com` for both inbound and outbound traffic on port 443. This is needed to download the initial deployment script from Forge. Whitelisting the IP addresses above will not work, because Forge uses Cloudflare dynamic proxied DNS.
+Your server should also allow incoming and outgoing traffic from `forge.laravel.com`.
 
 :::warning IP Address Changes
 

--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -37,6 +37,8 @@ If you are restricting SSH access to your server using IP allow lists, you shoul
 
 You can also access the IP addresses via the following URL: [https://forge.laravel.com/ips-v4.txt](https://forge.laravel.com/ips-v4.txt). This is particulary useful if you intend on automating your network or firewall infrastructure.
 
+Note that if your you are also restricting HTTPS traffic over port 443, you should also whitelist the domain `forge.laravel.com` for both inbound and outbound traffic on port 443. This is needed to download the initial deployment script from Forge. Whitelisting the IP addresses above will not work, because Forge uses Cloudflare dynamic proxied DNS.
+
 :::warning IP Address Changes
 
 The Forge IP addresses may change from time to time; however, we will always email you several weeks prior to an IP address change.


### PR DESCRIPTION
At the moment, the docs talk about whitelisting SSH access, but do not mention what's needed in very locked down environments where any inbound/outbound connection needs to be whitelisted. Forge cannot download it's initial deployment script if HTTPS traffic is being blocked, and simply whitelisting the standard IP addresses will not work, since Forge uses Cloudflare proxied DNS.