### PR TITLE
Bring docs design closer to main site

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,6 +1,5 @@
 module.exports = {
     title: "Laravel Forge",
-    description: "Laravel Hosting & Instant PHP Servers",
     base: '/docs/',
 
     plugins: [

--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -1,15 +1,14 @@
 body
-  background-color #eef1f4
   font-family "Nunito"
 
 /* Headings
 -----------------------------------------------------------------------------*/
 h1, h2, h3, h4, h5, h6
-  font-weight 300
+  color $headerTextColor
+  font-weight 700
 
 h1
-  padding-bottom 16px
-  border-bottom 2px solid rgba(0, 0, 0, 0.05)
+  font-weight 900
 
 h2
   border-bottom 0
@@ -17,12 +16,6 @@ h2
 /* Page
 -----------------------------------------------------------------------------*/
 @media (min-width 768px)
-  // .page
-  //   padding-left 13.75rem
-
-  .page-edit
-    // display none
-
   .page-nav
     padding 0
 
@@ -43,8 +36,6 @@ h2
 -----------------------------------------------------------------------------*/
 .navbar
   z-index 500
-  border-bottom none
-  box-shadow 0 2px 4px 0 rgba(0, 0, 0, .05)
 
 .navbar .logo
   max-width 60%
@@ -57,64 +48,13 @@ h2
 
 /* Sidebar
 -----------------------------------------------------------------------------*/
-/*
-#app
-  .sidebar
-    width 14rem
-    border-right none
-    background-color transparent
-    background-image linear-gradient(0deg, #7e8ea1 0%, #3c4655 100%)
-
-  .sidebar-heading
-    padding 0 1.4rem
-    margin-bottom: 0.5rem
-
-  .sidebar-group:not(.first)
-    margin-top: 0rem
-
-  .sidebar-group:not(.collapsable) .sidebar-heading,
-  .sidebar-heading
-    text-transform uppercase
-    letter-spacing 0.13rem
-    font-size 12px
-    font-weight 800
-    color #C1CDDB
-
-  a.sidebar-link
-    color #fff
-    border-left 0.125rem solid transparent
-
-  a.sidebar-link:hover
-    color #fff
-    opacity 0.5
-    border-left-color rgba(255, 255, 255, 0.7)
-
-  a.sidebar-link:active
-    color #fff
-    opacity 0.7
-    border-left-color rgba(255, 255, 255, 0.5)
-
-  a.sidebar-link.active
-    color #fff
-    border-left-color rgba(255, 255, 255, 0.5)
-
-  .sidebar-group a.sidebar-link
-    padding-left 1.5rem
-
-  @media (max-width 959px)
-    .sidebar .nav-links
-      border-bottom 2px solid rgba(255, 255, 255, 0.1)
-
-  @media (max-width 719px)
-    .nav-links a.nav-link, .nav-links a.repo-link
-      color #fff
-*/
-/* Sidebar ul, li, a, div spacing
------------------------------------------------------------------------------*/
 .sidebar-links
   > li:last-child
     margin 0
     margin-bottom: 2rem
+
+.sidebar .sidebar-group:not(.collapsable) .sidebar-heading:not(.clickable)
+    color $headerTextColor
 
 /* Icons
 -----------------------------------------------------------------------------*/
@@ -183,10 +123,6 @@ h6 .header-anchor:hover
 
 /* Prev/Next Links
 -----------------------------------------------------------------------------*/
-// @require './override'
-
-$tipColor = #A48CD3
-
 .prev, .next
   color $accentColor
 
@@ -236,7 +172,7 @@ div[class*="language-"]
   background-color white
   -webkit-font-smoothing subpixel-antialiased
   -moz-osx-font-smoothing subpixel-antialiased
-  box-shadow 0 2px 4px 0 rgba(0, 0, 0, .05)
+  box-shadow rgba(0, 0, 0, 0.15) 0px 10px 40px 0px
 
 .theme-default-content pre, .theme-default-content pre[class*="language-"]
   line-height 1.7

--- a/.vuepress/styles/palette.styl
+++ b/.vuepress/styles/palette.styl
@@ -1,2 +1,10 @@
-$accentColor = #4099DE
-$borderColor = #ddd
+$accentColor = rgb(24, 182, 155)
+$borderColor = rgb(229, 231, 235)
+$textColor = rgb(75, 85, 99)
+$codeBgColor = rgb(243, 244, 246)
+$accentColor = rgb(24, 182, 155)
+$borderColor = rgb(229, 231, 235)
+$textColor = rgb(75, 85, 99)
+$codeBgColor = rgb(243, 244, 246)
+$headerTextColor = rgb(17, 24, 39)
+$tipColor = rgb(164, 140, 211)


### PR DESCRIPTION
Switching from the site to the docs is kinda jarring and it has a lot of visual differences. It isn't perfect and there is still lots to do, but this brings the site pretty close the main sites design.

Also removed the description, as we are better off not having one than having the same on every page.

The code blocks aren't ideal, but I'll loop back to these and get them sorted as I roll a few other changes out.

Before...
![Screen Shot 2022-05-13 at 1 49 27 pm](https://user-images.githubusercontent.com/24803032/168207610-e74806ba-8361-464d-80f5-38056d29b3e9.png)

After...

![Screen Shot 2022-05-13 at 1 50 39 pm](https://user-images.githubusercontent.com/24803032/168207704-08ba1ffd-c7cc-4958-9441-2503f354a667.png)

