### PR TITLE
stop opening links in new tabs

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -2,6 +2,10 @@ module.exports = {
     title: "Laravel Forge",
     base: '/docs/',
 
+    markdown: {
+        externalLinks: { target: '_self', rel: false }
+    },
+
     plugins: [
         ['sitemap', {
             hostname: 'https://forge.laravel.com',
@@ -29,7 +33,7 @@ module.exports = {
         sidebarDepth: 0,
 
         nav: [
-            { text: 'Home', link: 'https://forge.laravel.com' }
+            { text: 'Home', link: 'https://forge.laravel.com', target: '_self', rel: false }
         ],
 
         sidebar: {


### PR DESCRIPTION
As it stands, a lot of links in the docs open in new tabs.

I believe the intention of this with vuepress is to open new tabs for links that are on different sites, however due to the nested nature of our docs it seems that it finds most links as external and opens them in new tabs.

Even links to other pages within the docs themselves open in new tabs.

As an example, if you navigate to: https://forge.laravel.com/docs/1.0/introduction.html and click the "server provider" link  under "what is forge" it will open a new tab and take you to that page of the docs.

I also don't feel in general we should be high-jacking the users link clicks and opening new tabs in any context. There are affordances offered by browsers to give the user the option to open in a new tab. We are removing that feature by having everything open in a new tab.