### PR TITLE
Intro + Edit link

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -25,6 +25,10 @@ module.exports = {
     ],
 
     themeConfig: {
+        repo: 'laravel/forge-docs',
+        editLinks: true,
+        editLinkText: 'Edit this page on GitHub',
+
         logo: '/assets/img/logo.svg',
         displayAllHeaders: false,
         activeHeaderLinks: false,

--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -46,6 +46,10 @@ h2
 .nav-link, .repo-link
   font-weight 800
 
+.navbar .repo-link {
+  display none
+}
+
 /* Sidebar
 -----------------------------------------------------------------------------*/
 .sidebar-links

--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -24,7 +24,7 @@ After connecting to your preferred [server provider](https://forge.laravel.com/d
 
 In addition, Forge can assist you in managing <a href="https://forge.laravel.com/docs/1.0/resources/scheduler.html">scheduled jobs</a>, <a href="https://forge.laravel.com/docs/1.0/sites/queues.html">queue workers</a>, <a href="https://forge.laravel.com/docs/1.0/sites/ssl.html">TLS/SSL certificates</a>, and more. After your server has provisioned, you can manage and deploy your web applications using the Forge UI dashboard.
 
-## Learning More
+## Video tutorials
 
 Laracasts has a comprehensive and **free** [video course](https://laracasts.com/series/learn-laravel-forge) on Forge. Feel free to review this course if you are new to Laravel Forge and want a video overview of its features.
 

--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -24,13 +24,9 @@ After connecting to your preferred [server provider](https://forge.laravel.com/d
 
 In addition, Forge can assist you in managing <a href="https://forge.laravel.com/docs/1.0/resources/scheduler.html">scheduled jobs</a>, <a href="https://forge.laravel.com/docs/1.0/sites/queues.html">queue workers</a>, <a href="https://forge.laravel.com/docs/1.0/sites/ssl.html">TLS/SSL certificates</a>, and more. After your server has provisioned, you can manage and deploy your web applications using the Forge UI dashboard.
 
-## Video tutorials
+## Video Tutorials
 
 Laracasts has a comprehensive and **free** [video course](https://laracasts.com/series/learn-laravel-forge) on Forge. Feel free to review this course if you are new to Laravel Forge and want a video overview of its features.
-
-:::tip Open Source Documentation
-Forge's documentation is completely [open source](https://github.com/laravel/forge-docs)! Please consider adding to it if you find something missing.
-:::
 
 ## Forge IP Addresses
 
@@ -55,5 +51,4 @@ Forge provides a powerful API that allows you to manage your servers programatic
 
 ## Found Something Wrong?
 
-If you find something in the documentation that is confusing or incorrect, please consider submitting a pull request on [GitHub](https://github.com/laravel/forge-docs).
-
+Have you found something in the documentation that is confusing or incorrect? Forge's documentation is completely open source! Please consider submitting a pull request on [GitHub](https://github.com/laravel/forge-docs).


### PR DESCRIPTION
This PR:

- Renames the "Learning More" section to "Video Tutorials" to make it more explicit when scanning just the headings.
- Removes the duplicate call out to help contribute to the docs.
- Adds a link to encourage users to contribute to the docs. We already ask users on the "Introduction" page, but this gives a quick link ("Edit this page on GitHub") to the exact page to make quick improvements to the docs.


![Screen Shot 2022-05-23 at 12 30 03 pm](https://user-images.githubusercontent.com/24803032/169732294-519753c1-a5a3-46af-81b5-0f944d29560b.png)

