### PR TITLE
fix build

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,10 +1,10 @@
 export default ({router}) => {
+    if (process.env.NODE_ENV === 'production' || typeof window === 'undefined') {
+        return
+    }
+
     // Google analytics...
     ((window, document, tagType, gaId, undefined) => {
-        if (process.env.NODE_ENV !== 'production' || window === undefined) {
-            return
-        }
-
         const existingTag = document.getElementsByTagName(tagType)[0]
         const tag = document.createElement(tagType)
         tag.async = 1


### PR DESCRIPTION
This was causing issues with the build as `window` is not defined. This new approach is the convention used in Vuepress plugins generally, so should do the trick.