### PR TITLE
standardise env variables

### DIFF
--- a/1.0/servers/nginx-templates.md
+++ b/1.0/servers/nginx-templates.md
@@ -29,29 +29,20 @@ Forge provides several variables that can be used within your templates to dynam
 
 | Variable | Description |
 | -------- | ----------- |
-| `DIRECTORY` | The site's configured web directory, e.g. `/public` |
-| `DOMAINS` | The site's configured domains to respond to, e.g. `laravel.com alias.laravel.com` |
-| `PATH` | The site's web accessible directory, e.g. `/home/forge/laravel.com/public` |
-| `PORT` | The IPv4 port the site should listen to (`:80`). If the site name is `default`, this variable will also contain `default_server` |
-| `PORT_V6` | The IPV6 port to listen to (`[::]:80`). If the site name is `default`, this variable will also contain `default_server` |
-| `PROXY_PASS` | The PHP socket to listen on, e.g. `unix:/var/run/php/php8.0-fpm.sock` |
-| `ROOT_PATH` | The root of the configured site, e.g. `/home/forge/laravel.com` |
-| `SERVER_PUBLIC_IP` | The public IP address of the server |
-| `SERVER_PRIVATE_IP` | The private IP address of the server, if available |
-| `SITE` | The site's name, e.g. `laravel.com`. This differs from `DOMAINS` in that it does not include site aliases. |
-| `SITE_ID` | The site's ID, e.g. `12345` |
-| `USER` | The site's user, e.g. `forge` |
+| `{{DIRECTORY}}` | The site's configured web directory, e.g. `/public` |
+| `{{DOMAINS}}` | The site's configured domains to respond to, e.g. `laravel.com alias.laravel.com` |
+| `{{PATH}}` | The site's web accessible directory, e.g. `/home/forge/laravel.com/public` |
+| `{{PORT}}` | The IPv4 port the site should listen to (`:80`). If the site name is `default`, this variable will also contain `default_server` |
+| `{{PORT_V6}}` | The IPV6 port to listen to (`[::]:80`). If the site name is `default`, this variable will also contain `default_server` |
+| `{{PROXY_PASS}}` | The PHP socket to listen on, e.g. `unix:/var/run/php/php8.0-fpm.sock` |
+| `{{ROOT_PATH}}` | The root of the configured site, e.g. `/home/forge/laravel.com` |
+| `{{SERVER_PUBLIC_IP}}` | The public IP address of the server |
+| `{{SERVER_PRIVATE_IP}}` | The private IP address of the server, if available |
+| `{{SITE}}` | The site's name, e.g. `laravel.com`. This differs from `{{DOMAINS}}` in that it does not include site aliases. |
+| `{{SITE_ID}}` | The site's ID, e.g. `12345` |
+| `{{USER}}` | The site's user, e.g. `forge` |
 
-The variables above may be used by wrapping them in double "curly braces". All of the following examples are examples of valid variable usage:
-
-<div v-pre>
-
-- `{{ PORT }}`
-- `{{PORT}}`
-- `{{ port }}`
-- `{{port}}`
-
-</div>
+When using these variables, you should ensure that they exactly match the syntax shown above.
 
 ## Managing Templates
 


### PR DESCRIPTION
We currently have 3 ways of providing variables to the user:

- [Nginx Template docs](https://forge.laravel.com/docs/1.0/servers/nginx-templates.html#template-variables)
- [Recipe docs](https://forge.laravel.com/docs/1.0/servers/recipes.html#variables)
- [Deployment script docs](https://forge.laravel.com/docs/1.0/sites/deployments.html#environment-variables)

The deployment script docs we can ignore, as that is a different mechanism and makes sense to have different.

However, with Nginx templates we allow the one variable to be specified in multiple ways...

```sh
# Upper case with spaces
{{ PORT }}

# Upper case without spaces
{{PORT}}

# Lower case with spaces
{{ port }}

# Lower case without spaces
{{port}}
```

For Recipes we only allow...

```sh
# Lower case without spaces
{{server_type}}
```

I'd like to propose that we only document and recommend "lower case without spaces" for the nginx templates rather than suggesting a matrix of options.

I'm not suggesting any functional changes to Forge - just that we only document one way of handling these so that it's less for the user to have to take on board / double check / make decisions about.

I could also imagine learning the Nginx templates way of doing things and then trying to apply that to recipes. 

Less moving parts.