### PR TITLE
fix CLI links

### DIFF
--- a/1.0/cli.md
+++ b/1.0/cli.md
@@ -1,5 +1,5 @@
 ---
-canonicalUrl: 'https://forge.laravel.com/docs/1.0/accounts/cli.html'
+canonicalUrl: 'https://forge.laravel.com/docs/1.0/cli.html'
 ---
 # CLI
 

--- a/1.0/sites/deployments.md
+++ b/1.0/sites/deployments.md
@@ -117,7 +117,7 @@ Additional data may be passed to your deployment script via query parameters pas
 
 ### Using Forge CLI
 
-If you would like to have access to the deployment output or execute additional deployment actions such as restarting services, you may use [Forge CLI](/1.0/accounts/cli.html).
+If you would like to have access to the deployment output or execute additional deployment actions such as restarting services, you may use [Forge CLI](/1.0/cli.html).
 
 Once you have installed Forge CLI, you may execute the `forge deploy` command in your CI platform's deployment pipeline.
 


### PR DESCRIPTION
When we moved the CLI docs, we didn't update the links to it.