### PR TITLE
Update Forge IP Addresses after upgrade

### DIFF
--- a/1.0/introduction.md
+++ b/1.0/introduction.md
@@ -35,9 +35,6 @@ Laracasts has a comprehensive and **free** [video course](https://laracasts.com/
 
 In order to provision and communicate with your servers, Forge requires SSH access to them. If you have set up your servers to restrict SSH access using IP allow lists, you must allow the following Forge IP addresses:
 
-- `159.203.161.246`
-- `159.203.163.240`
-- `68.183.145.91`
 - `159.203.150.232`
 - `159.203.150.216`
 - `45.55.124.124`

--- a/1.0/servers/providers.md
+++ b/1.0/servers/providers.md
@@ -40,9 +40,6 @@ There are a few requirements you should review to ensure Forge works correctly w
 | HTTP  | TCP      | 80         | Custom | 0.0.0.0/0          |                  |
 | HTTP  | TCP      | 80         | Custom | ::/0               |                  |
 | SSH   | TCP      | 22         | Custom | YOUR_IP_ADDRESS/32 | SSH from your IP |
-| SSH   | TCP      | 22         | Custom | 159.203.161.246/32 | SSH from Forge   |
-| SSH   | TCP      | 22         | Custom | 159.203.163.240/32 | SSH from Forge   |
-| SSH   | TCP      | 22         | Custom | 68.183.145.91/32   | SSH from Forge   |
 | SSH   | TCP      | 22         | Custom | 159.203.150.232/32 | SSH from Forge   |
 | SSH   | TCP      | 22         | Custom | 159.203.150.216/32 | SSH from Forge   |
 | SSH   | TCP      | 22         | Custom | 45.55.124.124/32   | SSH from Forge   |


### PR DESCRIPTION
Since the upgrade, 3 IP addresses were removed from the infrastructure estate. Firewalls can and should be updated to reflect this change.