### PR TITLE
Reflect new minimal requirements

### DIFF
--- a/1.0/servers/cookbook.md
+++ b/1.0/servers/cookbook.md
@@ -91,6 +91,7 @@ To ensure Forge works correctly with AWS, please review [these requirements](/1.
 There are several reasons why your server may have a "disconnected" status. We encourage you to check these common solutions before contacting support:
 
 - Verify that the server is powered on via your server provider's dashboard. If the server is powered off, you should restart it using your **provider's dashboard**.
+- Verify that the public IP address of the server is known to Forge (the public IP address may change between reboots of the actual VPS).
 - Verify that the Forge generated public key for the server is included in the `/root/.ssh/authorized_keys` and `/home/forge/.ssh/authorized_keys` files. This key is available via the "Meta" tab of your server's Forge management panel.
 - If your server is behind a firewall, make sure you have [allowed Forge's IP addresses to access the server](/1.0/introduction.html#forge-ip-addresses).
 - If you removed Port 22 from the server's firewall rules, you will need to contact your server provider and ask them to restore the rule. Removing this rule prevents Forge from accessing your server via SSH.

--- a/1.0/servers/providers.md
+++ b/1.0/servers/providers.md
@@ -68,7 +68,7 @@ In addition, you should review the following server requirements:
 - The server **must be** running a fresh installation of Ubuntu 20.04 / 22.04 x64.
 - The server **must be** accessible externally over the Internet.
 - The server **must have** `root` SSH access enabled.
-- The server requirements **must meet** the following criteria or more: 1 CPU Core with 1GHz, 512MB RAM, and 10GB Disk space.
+- The server requirements **should meet** the following criteria or more: 1 CPU Core with 1GHz, 1GB RAM, and 10GB Disk space.
 - The server **must have** curl installed.
 
 Please refer to the [Forge IP address documentation](/1.0/introduction.html#forge-ip-addresses) if you restrict SSH access to your server by IP addresses.

--- a/1.0/servers/providers.md
+++ b/1.0/servers/providers.md
@@ -68,7 +68,7 @@ In addition, you should review the following server requirements:
 - The server **must be** running a fresh installation of Ubuntu 20.04 / 22.04 x64.
 - The server **must be** accessible externally over the Internet.
 - The server **must have** `root` SSH access enabled.
-- The server requirements **must meet** the following criteria or more: 1 CPU Core with 1GHz, 1GB RAM, and 25GB Disk space.
+- The server requirements **must meet** the following criteria or more: 1 CPU Core with 1GHz, 512MB RAM, and 10GB Disk space.
 - The server **must have** curl installed.
 
 Please refer to the [Forge IP address documentation](/1.0/introduction.html#forge-ip-addresses) if you restrict SSH access to your server by IP addresses.


### PR DESCRIPTION
Since DigitalOcean introduced their new $4 server, we have supported it, however our documentation did not reflect that.