### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/1.0/sites/deployments.md
+++ b/1.0/sites/deployments.md
@@ -145,9 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.5.3
+        uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Setup PHP


### PR DESCRIPTION
This Updates to the latest GitHub Actions Dependencies. 

- actions/checkout@v2 -> v3
- webfactory/ssh-agent@0.5.3 -> 0.7.0

Links for confirmation:
- https://github.com/actions/checkout/releases/tag/v3.1.0
- https://github.com/webfactory/ssh-agent/releases
