### PR TITLE
Align GitHub Actions example with Chipper CI example

### DIFF
--- a/1.0/sites/deployments.md
+++ b/1.0/sites/deployments.md
@@ -153,7 +153,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           tools: composer:v2
           coverage: none
       - name: Require Forge CLI


### PR DESCRIPTION
I suggest aligning the GitHub Actions example with the Chipper CI example to use the same PHP version. 

Not a big deal, but I have been at it anyways with a different tiny PR for the docs. 