### PR TITLE
Update `rewrite` regex syntax

### DIFF
--- a/1.0/sites/redirects.md
+++ b/1.0/sites/redirects.md
@@ -11,7 +11,7 @@ Forge allows you to configure redirects that can be configured to automatically 
 
 ## Creating Redirects
 
-Redirects are wrappers around Nginx's [`rewrite` rules](https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite) and can use the full redirect syntax supported by Nginx, including regular expressions. For example, you could use `= /` to only match the root of the domain.
+Redirects are wrappers around Nginx's [`rewrite` rules](https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#rewrite) and can use the full redirect syntax supported by Nginx, including regular expressions. For example, you could use `^/$` to only match the root of the domain.
 
 ## Temporary vs. Permanent Redirects
 


### PR DESCRIPTION
Maybe `= /` used to work in the past when matching the root directory only, but in recent versions, `^/$` is supported and `= /` will throw an error: Too many arguments for the rewrite rule.