### PR TITLE
Update docs on how to upgrade Node

### DIFF
--- a/src/servers/cookbook.md
+++ b/src/servers/cookbook.md
@@ -66,9 +66,11 @@ You should upgrade the Nginx version on your server at your own risk. Upgrading 
 The latest version of Node.js is installed by Forge when it is provisioning a new server. However, as your server ages, you may wish to upgrade the version of Node.js:
 
 ```bash
-curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash -
-
-sudo apt-get install -y nodejs
+sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update && sudo apt-get install nodejs -y
 ```
 
 [Node.js version information](https://nodejs.org/en/about/previous-releases/)


### PR DESCRIPTION
Updated as the nodesource script is now deprecated.

https://deb.nodesource.com/node_latest.x