### PR TITLE
Replace i-grave with a regular i on the 'user-isolation' page

### DIFF
--- a/src/sites/user-isolation.md
+++ b/src/sites/user-isolation.md
@@ -21,7 +21,7 @@ Like the `forge` user, newly created isolated users also have limited sudo acces
 sudo -S service php8.1-fpm reload
 ```
 
-If you need further sudo access, you should login as the `forge` user and switch to the `root` user using the `sudo su` or the `sudo -ì` command.
+If you need further sudo access, you should login as the `forge` user and switch to the `root` user using the `sudo su` or the `sudo -i` command.
 
 ## Connecting Via SFTP
 


### PR DESCRIPTION
On the user-isolation page the sudo command had an `ì` character instead of a regular `i`. This PR fixes this.