### PR TITLE
added --allow-releaseinfo-change option explicitly

### DIFF
--- a/src/servers/cookbook.md
+++ b/src/servers/cookbook.md
@@ -66,12 +66,12 @@ You should upgrade the Nginx version on your server at your own risk. Upgrading 
 The latest version of Node.js is installed by Forge when it is provisioning a new server. However, as your server ages, you may wish to upgrade the version of Node.js:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
+sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 NODE_MAJOR=20
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-sudo apt-get update && sudo apt-get install nodejs -y
+sudo apt-get update --allow-releaseinfo-change && sudo apt-get install nodejs -y
 ```
 
 [Node.js version information](https://nodejs.org/en/about/previous-releases/)


### PR DESCRIPTION
added **_--allow-releaseinfo-change_** option explicitly to automatically accept any changes in the release information of a repository.

This is to avoid getting errors that cause the upgrade to fail. (e.g. Node version, PHP version)

![image](https://github.com/laravel/forge-docs/assets/15418147/77e55753-5048-43c9-be92-26b9e790c296)
